### PR TITLE
Cleaned up memory usage, Using macros to define songs

### DIFF
--- a/bassdll/bassdll.cpp
+++ b/bassdll/bassdll.cpp
@@ -23,23 +23,24 @@
 
 void channel::next()
 {
-  duration_sum += notes[current].duration * 10;
+  duration_sum += get_note(current).duration * 10;
   current++;
-  if (current==insert_at) current = 0;
+  if (current==pattern_len) current = 0;
 }
 
 channel::channel(int apin, int how_many_notes)
 {
   pinMode(apin,OUTPUT);
   halflife = 0;
-  //next_invert_time = 0;
- // nextTime = 0;  
   pin = apin;
-//  notes = NULL;
-  realloc_notes();
+  pattern_len = 0;
   init();
-  
- // debug(sizeof(note*) * how_many_notes);
+}
+
+void channel::set_pattern(prog_uint16_t* pattern, int pattern_len)
+{
+    this->pattern = pattern;
+    this->pattern_len = pattern_len;
 }
 
 void channel::init()
@@ -56,9 +57,9 @@ void channel::init()
 
 void channel::setupNote(unsigned long started_playing_time)
 {
+ note solonote = get_note(current);
 
-      note solonote = notes[current];
- switch(notes[current].tone)
+ switch(get_note(current).tone)
  {
    //hacks for various notes
    case KICK:
@@ -73,27 +74,24 @@ void channel::setupNote(unsigned long started_playing_time)
      transpose++;
      break;
    case TRANSPOSEDOWN:
-   /// debug(444);
      transpose--;
      halflife = INT_MAX;
      break;
    case SUPERSOLO: 
-
      supersolo = solonote.duration;
-     solonote.duration = 0;
-     next();
-     solonote.duration = supersolo; //restore duration for the next loop
+     current++;
+     if (current==pattern_len) current = 0;
      setupNote(started_playing_time); //fake out everything
      return;
      break;
     default:
-     halflife = 500000/fixTone(notes[current].tone + transpose);
+     halflife = 500000/fixTone(get_note(current).tone + transpose);
      break; 
  }
  if (halflife <0) halflife = INT_MAX; //we use negative number on occasion for things like rests...
  unsigned long old_nextTime = nextTime;
   nextTime = started_playing_time + ((unsigned long) //instruct the compiler that this is going to get BIG... otherwise things overflow here
- duration_sum + notes[current].duration*10)*1000;
+ duration_sum + get_note(current).duration*10)*1000;
  next_invert_time = old_nextTime + halflife;
 
 }
@@ -106,9 +104,8 @@ void mixer::dump()
       channel* c = channels[i];
       Serial.print("Channel ");
       Serial.println(i);
-      note* notes = c->notes;
-      for (int j = 0; j < c->insert_at; j++) {
-        note n = notes[j];
+      for (int j = 0; j < c->pattern_len; j++) {
+        note n = c->get_note(j);
         Serial.print("(");
         Serial.print(n.tone);
         Serial.print(", ");
@@ -119,21 +116,13 @@ void mixer::dump()
      }
 }
 
-
-
-
-void channel::realloc_notes()
-{
-    insert_at = 0;
-}
 channel::~channel()
 {
-  //free(notes);
 }
 
 inline void channel::notehacks ()
 {
-  switch(notes[current].tone)
+  switch(get_note(current).tone)
   {
     case KICK:
       
@@ -161,7 +150,7 @@ inline void channel::notehacks ()
   //supersolo hack
   if (supersolo!=0 && (ssinterval--)%supersolo==0)
   {
-    char super = (notes[current+1].tone > notes[current].tone)?-1:1;
+    char super = (get_note(current+1).tone > get_note(current).tone)?-1:1;
    // halflife *= ((1 + (.01*super)) * supersolo/10.);
    halflife += super;
   }
@@ -191,25 +180,16 @@ void mixer::play()
      for(int i = 0; i < max_channel; i++)
      {
        
-      // debug(0);
-      //note* current = channels[i]->notes[channels[i]->current];
-     // if (channels[i]->notes[channels[i]->current]->tone==REST) continue; //not the minDelay
-      if (channels[i]->notes[channels[i]->current].tone==STOP) return;
+      if (channels[i]->get_note(channels[i]->current).tone==STOP) return;
        if (channels[i]->next_invert_time < minDelay)
        {
          minDelay = channels[i]->next_invert_time;
          active = channels[i];
        }
      }
-     //minDelay = channels[2]->next_invert_time;
-     //active = channels[2];
-     if (active==NULL) debug(997);
-    // if (channels[0]->current->now.tone==9 && minDelay != 1353 && minDelay != 676) debug(minDelay);
      //BLOCK
-    // note* current = active->notes[active->current];
-     if (active->notes[active->current].tone!=REST)
+     if (active->get_note(active->current).tone!=REST)
          active->position = ! active->position;
- // if(active==channels[0])if(active->next_invert_time > channels[2]->next_invert_time) debug(1024);
   while (micros() < minDelay){}
      lastClock = micros();
 	  
@@ -222,28 +202,10 @@ void mixer::play()
 
        if (lastClock >= channels[i]->nextTime)
        {
-                //   if (++a==2) debug(0);
-         //debug(channels[i]->nextTime);
-      //  debug(0);
         channels[i]->next();
          channels[i]->setupNote(wall_clock_time);
-        // debug(channels[i]->nextTime);
-        //a++;
-       // channels[i]->setupNote(0); 
-
        } 
-      // debug(sizeof(channels[0]->nextTime));
-      // if (channels[0]->nextTime - lastClock > 50000) debug (channels[0]->duration_sum);
-      // if (lastClock < 1000000 && channels[0]->current->now.tone==4) debug(lastClock)   ;    
-
-
-
      }  
-  
-     
-     
-     
-a++;
   }
 }
 void mixer::add_channel(channel* x)

--- a/bassdll/bassdll.h
+++ b/bassdll/bassdll.h
@@ -31,8 +31,7 @@
 #include <limits.h>
 #include <math.h>
 
-
-
+#define NELEMENTS(x)  (sizeof(x) / sizeof(x[0]))
 
 #define MAGIC 1.0594631
 inline int fixTone(signed char tone)
@@ -54,6 +53,11 @@ inline int fixTone(signed char tone)
  struct note {
   signed char tone;
   unsigned char duration;
+ note() {}
+ note(signed char tone, unsigned char duration) {
+  this->tone = tone;
+  this->duration = duration;
+ }
 };
 ///CHANNEL
 class channel
@@ -69,7 +73,6 @@ class channel
       void init();
 void setupNote(unsigned long started_playing_time);
     void next();
-    void queue(note* n);
     void fixHigh();
     void fixLow();
     inline void notehacks();
@@ -88,7 +91,7 @@ void setupNote(unsigned long started_playing_time);
     unsigned char supersolo; //supersolo value
     unsigned char ssinterval; //supersolo interval
     
-    note **notes;
+    note *notes;
     int current;
     
 
@@ -104,6 +107,6 @@ class mixer
     mixer();
     void add_channel(channel*x);
     void play();
-   
+    void dump();
 };
 #endif

--- a/demos/core2/core2.pde
+++ b/demos/core2/core2.pde
@@ -32,11 +32,11 @@ channel pin10 (13,1);
 #define SNARE_LEN 7
 
 //pt 3
-#define kick  note(KICK, KICK_LEN), note(REST, EIGHTH-KICK_LEN),
-#define snare note(SNARE, SNARE_LEN), note(REST, EIGHTH-SNARE_LEN),
-#define rest  note(REST, EIGHTH),
+#define kick  NOTE(KICK, KICK_LEN), NOTE(REST, EIGHTH-KICK_LEN),
+#define snare NOTE(SNARE, SNARE_LEN), NOTE(REST, EIGHTH-SNARE_LEN),
+#define rest  NOTE(REST, EIGHTH),
 
-note drum_loop[] = {
+PATTERN(drum_loop) = {
   kick rest rest kick
   rest rest kick rest
   rest rest kick rest
@@ -58,20 +58,20 @@ note drum_loop[] = {
   snare rest snare rest
 };
 
-#define gsharp      note(-13, EIGHTH),
-#define gsharp4     note(-13, 4*EIGHTH),
-#define gsharp2low  note(-25, 2*EIGHTH),
-#define gsharp2high note(-13, 2*EIGHTH),
-#define transpose   note(TRANSPOSEUP, 0),
-#define transposed  note(TRANSPOSEDOWN, 0),  
-#define g2          note(-14, 2*EIGHTH),
-#define c           note(-9, EIGHTH),
-#define c4          note(-9, 4*EIGHTH),
-#define c2          note(-9, 2*EIGHTH),
-#define lowc        note(-21, EIGHTH),
-#define lowc4       note(-21, 4*EIGHTH),
+#define gsharp      NOTE(-13, EIGHTH),
+#define gsharp4     NOTE(-13, 4*EIGHTH),
+#define gsharp2low  NOTE(-25, 2*EIGHTH),
+#define gsharp2high NOTE(-13, 2*EIGHTH),
+#define transpose   NOTE(TRANSPOSEUP, 0),
+#define transposed  NOTE(TRANSPOSEDOWN, 0),  
+#define g2          NOTE(-14, 2*EIGHTH),
+#define c           NOTE(-9, EIGHTH),
+#define c4          NOTE(-9, 4*EIGHTH),
+#define c2          NOTE(-9, 2*EIGHTH),
+#define lowc        NOTE(-21, EIGHTH),
+#define lowc4       NOTE(-21, 4*EIGHTH),
 
-note part3_bassline[] = {
+PATTERN(part3_bassline) = {
   gsharp rest rest gsharp rest rest
   gsharp4 gsharp2low gsharp2high gsharp2low
   transpose transpose
@@ -86,30 +86,32 @@ note part3_bassline[] = {
 
 //sky notes
 
-#define sc       note(3,  EIGHTH),
-#define sgsharp  note(-1, EIGHTH),
-#define sf       note(-4, EIGHTH),
-#define sasharp  note(1,  EIGHTH),
-#define sg       note(-2, EIGHTH),
-#define se       note(-5, EIGHTH),
-#define sdu      note(5,  EIGHTH),
-#define seu      note(7,  EIGHTH),
-#define sfu      note(8,  EIGHTH),
-#define scd      note(-9, EIGHTH),
-#define sgu      note(10, EIGHTH),
-#define scu      note(15, EIGHTH),
-#define sbu      note(14, EIGHTH),
-#define sd       note(-7, EIGHTH),
-#define stop     note(STOP, 0),
-#define sgsharpu note(11, EIGHTH),
-#define sasharpu note(13, EIGHTH),
-#define sduu     note(17, EIGHTH),
-#define seuu     note(19, EIGHTH),
-#define sguu     note(22, EIGHTH),
-#define nulln    note(REST, EIGHTH * 16),
-#define scuu     note(27, EIGHTH * 16),
+#define sc       NOTE(3,  EIGHTH),
+#define sgsharp  NOTE(-1, EIGHTH),
+#define sf       NOTE(-4, EIGHTH),
+#define sasharp  NOTE(1,  EIGHTH),
+#define sg       NOTE(-2, EIGHTH),
+#define se       NOTE(-5, EIGHTH),
+#define sdu      NOTE(5,  EIGHTH),
+#define seu      NOTE(7,  EIGHTH),
+#define sfu      NOTE(8,  EIGHTH),
+#define scd      NOTE(-9, EIGHTH),
+#define sgu      NOTE(10, EIGHTH),
+#define scu      NOTE(15, EIGHTH),
+#define sbu      NOTE(14, EIGHTH),
+#define sd       NOTE(-7, EIGHTH),
+#define stop     NOTE(STOP, 0),
+#define sgsharpu NOTE(11, EIGHTH),
+#define sasharpu NOTE(13, EIGHTH),
+#define sduu     NOTE(17, EIGHTH),
+#define seuu     NOTE(19, EIGHTH),
+#define sguu     NOTE(22, EIGHTH),
+#define nulln    NOTE(REST, EIGHTH * 16),
+#define scuu     NOTE(27, EIGHTH * 16),
 
-note part3_sky[] = {
+PATTERN(part3_sky) = {
+  NOTE(1,2), NOTE(3,4), NOTE(5,6),
+  NOTE(-1,2), NOTE(-3,4), NOTE(-5,6),
   sc sgsharp sf sgsharp
   sc sgsharp sf sgsharp
   sc sgsharp sf sgsharp
@@ -190,60 +192,55 @@ note part3_sky[] = {
   stop
 };
 
-note part3_null[] = {
+PATTERN(part3_null) = {
   nulln
 };
-note part3_end[] = {
+
+PATTERN(part3_end) = {
   scuu stop
 };
 
 void pt3(channel &drums, channel &bassline, channel& sky)
 {
-  drums.notes = drum_loop;
-  drums.insert_at = NELEMENTS(drum_loop);
-  bassline.notes = part3_bassline;
-  bassline.insert_at = NELEMENTS(part3_bassline);
-  sky.notes = part3_sky;
-  sky.insert_at = NELEMENTS(part3_sky);  
+  SET_PATTERN(drums, drum_loop);
+  SET_PATTERN(bassline, part3_bassline);
+  SET_PATTERN(sky, part3_sky);
   m.play();
 
-  drums.notes = part3_null;
-  drums.insert_at = NELEMENTS(part3_null);
-  bassline.notes = part3_null;
-  bassline.insert_at = NELEMENTS(part3_null);
-  sky.notes = part3_end;
-  sky.insert_at = NELEMENTS(part3_end);
+  SET_PATTERN(drums, part3_null);
+  SET_PATTERN(bassline, part3_null);
+  SET_PATTERN(sky, part3_end);
   m.play();
 }
 
-#define sc note(27, EIGHTH),
-#define sg note(22, EIGHTH),
-#define se note(19, EIGHTH),
-#define sgsharp note(23, EIGHTH),
-#define sf note(20, EIGHTH),
-#define sd note(29, EIGHTH),
-#define sasharp note(25, EIGHTH),
-#define mclong note(3, EIGHTH * 10),
-#define melong note(7, EIGHTH * 10),
-#define mg note(-2, EIGHTH * 2),
-#define hg note(10, EIGHTH*2),
-#define mc note(3, EIGHTH * 2),
-#define me note(7, EIGHTH * 2),
-#define mf note(8, EIGHTH * 4),
-#define md4 note(5, EIGHTH * 4),
-#define me4 note(7, EIGHTH * 4),
-#define mc4 note(3, EIGHTH * 4),
-#define mchold note(3, EIGHTH * 24),
-#define mchold2 note(3, EIGHTH*10),
-#define mghold note(10, EIGHTH * 24),
-#define mghold2 note(10, EIGHTH*10),
-#define ma4 note(12, EIGHTH * 4),
-#define mg4 note(10, EIGHTH * 4),
-#define mgsharphold note(11, EIGHTH * 18), 
-#define masharphold note(13, EIGHTH * 16),
-#define mfhold note(8, EIGHTH * 16), 
+#define sc          NOTE(27, EIGHTH),
+#define sg          NOTE(22, EIGHTH),
+#define se          NOTE(19, EIGHTH),
+#define sgsharp     NOTE(23, EIGHTH),
+#define sf          NOTE(20, EIGHTH),
+#define sd          NOTE(29, EIGHTH),
+#define sasharp     NOTE(25, EIGHTH),
+#define mclong      NOTE( 3, EIGHTH * 10),
+#define melong      NOTE( 7, EIGHTH * 10),
+#define mg          NOTE(-2, EIGHTH * 2),
+#define hg          NOTE(10, EIGHTH * 2),
+#define mc          NOTE( 3, EIGHTH * 2),
+#define me          NOTE( 7, EIGHTH * 2),
+#define mf          NOTE( 8, EIGHTH * 4),
+#define md4         NOTE( 5, EIGHTH * 4),
+#define me4         NOTE( 7, EIGHTH * 4),
+#define mc4         NOTE( 3, EIGHTH * 4),
+#define mchold      NOTE( 3, EIGHTH * 24),
+#define mchold2     NOTE( 3, EIGHTH * 10),
+#define mghold      NOTE(10, EIGHTH * 24),
+#define mghold2     NOTE(10, EIGHTH * 10),
+#define ma4         NOTE(12, EIGHTH * 4),
+#define mg4         NOTE(10, EIGHTH * 4),
+#define mgsharphold NOTE(11, EIGHTH * 18), 
+#define masharphold NOTE(13, EIGHTH * 16),
+#define mfhold      NOTE( 8, EIGHTH * 16), 
 
-note part1_skyline[] = {
+PATTERN(part1_skyline) = {
   sc sg se sg
   sc sg se sg
   sc sg se sg
@@ -286,8 +283,7 @@ note part1_skyline[] = {
   sc
 };
 
-
-note part1_melody[] = {
+PATTERN(part1_melody) = {
   mclong
   mg
   mc
@@ -314,7 +310,7 @@ note part1_melody[] = {
 };
 
 
-note part1_harmony[] = {
+PATTERN(part1_harmony) = {
   transposed transposed transposed transposed transposed transposed
   transposed transposed transposed transposed transposed transposed
 
@@ -345,22 +341,19 @@ note part1_harmony[] = {
 
 void pt1(channel& melody, channel& harmony, channel& skyline)
 {
-  melody.notes = part1_melody;
-  melody.insert_at = NELEMENTS(part1_melody);
-  harmony.notes = part1_harmony;
-  harmony.insert_at = NELEMENTS(part1_harmony);
-  skyline.notes = part1_skyline;
-  skyline.insert_at = NELEMENTS(part1_skyline);
+  SET_PATTERN(melody, part1_melody);
+  SET_PATTERN(harmony, part1_harmony);
+  SET_PATTERN(skyline, part1_skyline);  
   m.play();
 }
 
-#define bc note(-21, EIGHTH),
-#define bc2 note(-21, EIGHTH * 2),
-#define bchigh note(-9, EIGHTH * 2),
-#define bgsharp note(-13, EIGHTH * 2),
-#define basharp note(-11, EIGHTH * 2),
+#define bc      NOTE(-21, EIGHTH),
+#define bc2     NOTE(-21, EIGHTH * 2),
+#define bchigh  NOTE(-9, EIGHTH * 2),
+#define bgsharp NOTE(-13, EIGHTH * 2),
+#define basharp NOTE(-11, EIGHTH * 2),
 
-note part2_bassline[] = {
+PATTERN(part2_bassline) = {
   bc2 rest
   bc2 rest 
   bc2 rest
@@ -390,38 +383,38 @@ note part2_bassline[] = {
   bchigh bgsharp  
 };
 
-#define mch note(-9, EIGHTH*10),
-#define mg note(-14, EIGHTH*2),
-#define mg4 note(-14, EIGHTH*4),
-#define mg1 note(-14, EIGHTH*1),
-#define mgold note(-2, EIGHTH * 12),
-#define mc note(-9, EIGHTH * 2),
-#define mcsharp1 note(-8, EIGHTH),
-#define mc1 note(-9, EIGHTH * 1),
-#define mcl note(-21, EIGHTH * 2),
-#define mc4 note(-9, EIGHTH * 4),
-#define me note(-5, EIGHTH * 2),
-#define me1 note(-5, EIGHTH * 1),
-#define mel8 note(-17, EIGHTH * 8),
-#define mf4 note(-4, EIGHTH * 4),
-#define mfl1 note(-16, EIGHTH),
-#define mf note(-4, EIGHTH * 2),
-#define mf1 note(-4, EIGHTH),
-#define md1 note(-7, EIGHTH),
-#define mdl note(-19, EIGHTH * 2),
-#define md4 note(-7, EIGHTH * 4),
-#define me4 note(-5, EIGHTH * 4),
-#define mchh note(-9, EIGHTH * 14),
-#define mcsecondhh note(-9, EIGHTH * 8),
-#define soloON note(SUPERSOLO, 1),
-#define soloOFF note(SUPERSOLO, 0),
-#define mgsharp note(-13, 2 * EIGHTH),
-#define mgsharp10 note(-13, 10 * EIGHTH),
-#define frest note(REST, EIGHTH / 2),
-#define moreSOLO note(SUPERSOLO, 1),
-#define stop note(STOP, 0),
+#define mch        NOTE(-9, EIGHTH*10),
+#define mg         NOTE(-14, EIGHTH*2),
+#define mg4        NOTE(-14, EIGHTH*4),
+#define mg1        NOTE(-14, EIGHTH*1),
+#define mgold      NOTE(-2, EIGHTH * 12),
+#define mc         NOTE(-9, EIGHTH * 2),
+#define mcsharp1   NOTE(-8, EIGHTH),
+#define mc1        NOTE(-9, EIGHTH * 1),
+#define mcl        NOTE(-21, EIGHTH * 2),
+#define mc4        NOTE(-9, EIGHTH * 4),
+#define me         NOTE(-5, EIGHTH * 2),
+#define me1        NOTE(-5, EIGHTH * 1),
+#define mel8       NOTE(-17, EIGHTH * 8),
+#define mf4        NOTE(-4, EIGHTH * 4),
+#define mfl1       NOTE(-16, EIGHTH),
+#define mf         NOTE(-4, EIGHTH * 2),
+#define mf1        NOTE(-4, EIGHTH),
+#define md1        NOTE(-7, EIGHTH),
+#define mdl        NOTE(-19, EIGHTH * 2),
+#define md4        NOTE(-7, EIGHTH * 4),
+#define me4        NOTE(-5, EIGHTH * 4),
+#define mchh       NOTE(-9, EIGHTH * 14),
+#define mcsecondhh NOTE(-9, EIGHTH * 8),
+#define soloON     NOTE(SUPERSOLO, 1),
+#define soloOFF    NOTE(SUPERSOLO, 0),
+#define mgsharp    NOTE(-13, 2 * EIGHTH),
+#define mgsharp10  NOTE(-13, 10 * EIGHTH),
+#define frest      NOTE(REST, EIGHTH / 2),
+#define moreSOLO   NOTE(SUPERSOLO, 1),
+#define stop       NOTE(STOP, 0),
 
-note part2_melody[] = {
+PATTERN(part2_melody) = {
   mch mg mc me mf4 me md4
   me soloON me soloOFF mchh
   rest rest rest rest
@@ -451,16 +444,14 @@ note part2_melody[] = {
 
 void pt2(channel& melody, channel& bassline, channel& drums)
 {
-  drums.notes = drum_loop;
-  drums.insert_at = NELEMENTS(drum_loop);
-  bassline.notes = part2_bassline;
-  bassline.insert_at = NELEMENTS(part2_bassline);
-  melody.notes = part2_melody;
-  melody.insert_at = NELEMENTS(part2_melody);
+  SET_PATTERN(drums, drum_loop);
+  SET_PATTERN(bassline, part2_bassline);
+  SET_PATTERN(melody, part2_melody);
   m.play();
 }
 
 void setup(){
+  Serial.begin(115200);
   m.add_channel(&pin10);
   m.add_channel(&pin11);
   m.add_channel(&pin12); //LOUD PIN
@@ -468,6 +459,6 @@ void setup(){
 
 void loop() {
   pt1(pin10,pin11,pin12);
-  pt2(pin12,pin11,pin10);
-  pt3(pin12,pin11,pin10);
+  pt2(pin10,pin11,pin12);
+  pt3(pin10,pin11,pin12);
 }

--- a/demos/core2/core2.pde
+++ b/demos/core2/core2.pde
@@ -21,1131 +21,453 @@
 
 #include <bassdll.h>
 #include <debug.h>
- void pt3(channel &drums, channel &bassline, channel& sky);
-  void pt2(channel &drums, channel &bassline, channel& sky);
-   void pt1(channel &drums, channel &bassline, channel& sky);
 
 mixer m;
-note** memblk;
-channel pin12(12,1);
+channel pin12 (10,1);
 channel pin11 (11,1);
-channel pin10 (10,1);
-void setup(){
-memblk = (note**) calloc(290,sizeof(note*));
-  if (memblk==NULL) debug(1111);
-
-m.add_channel(&pin10);
-m.add_channel(&pin11);
-m.add_channel(&pin12); //LOUD PIN
-
-  
-}
-
-void loop() {
-
-  {pt1(pin10,pin11,pin12);}
-    {pt2(pin12,pin11,pin10);}
-
-
-    {pt3(pin12,pin11,pin10);}
-}
-
-
-
-
+channel pin10 (13,1);
 
 #define EIGHTH 10
 #define KICK_LEN 9
 #define SNARE_LEN 7
 
 //pt 3
+#define kick  note(KICK, KICK_LEN), note(REST, EIGHTH-KICK_LEN),
+#define snare note(SNARE, SNARE_LEN), note(REST, EIGHTH-SNARE_LEN),
+#define rest  note(REST, EIGHTH),
 
-inline void pt3(channel &drums, channel &bassline, channel& sky)
-{
- ///OK HERES THE DRUM LOOP
-  note kick;
-  kick.tone = KICK;
-  kick.duration = KICK_LEN;
-  
-  note kick_rest;
-  kick_rest.tone = REST;
-  kick_rest.duration = EIGHTH-KICK_LEN;
-  
-  note snare;
-  snare.tone = SNARE;
-  snare.duration = SNARE_LEN;
-  
-  note snare_rest;
-  snare_rest.tone = REST;
-  snare_rest.duration = EIGHTH-SNARE_LEN;
-  
-  note rest;
-  rest.tone = REST;
-  rest.duration = EIGHTH;
-  
-  //bassline notes
-    note gsharp;
-  gsharp.tone = -13;
-  gsharp.duration = EIGHTH;
-  
-  note gsharp4;
-  gsharp4.tone = -13;
-  gsharp4.duration = 4 * EIGHTH;
-  
-  note gsharp2low;
-  gsharp2low.tone = -25;
-  gsharp2low.duration = 2 * EIGHTH;
-  
-  note gsharp2high;
-  gsharp2high.tone = -13;
-  gsharp2high.duration = 2*EIGHTH;
-  
-  note transpose;
-  transpose.tone = TRANSPOSEUP;
-  transpose.duration = 0;
-  
-  note transposed;
-  transposed.tone = TRANSPOSEDOWN;
-  transposed.duration = 0;
-  
-  note g2;
-  g2.tone = -14;
-  g2.duration = 2*EIGHTH;
-  
-  note c;
-  c.tone = -9;
-  c.duration = EIGHTH;
-  
-  note c4;
-  c4.tone = -9;
-  c4.duration = 4*EIGHTH;
-  
-  note c2;
-  c2.tone = -9;
-  c2.duration = 2*EIGHTH;
-  
-  note lowc;
-  lowc.tone = -21;
-  lowc.duration = EIGHTH;
-  
-  note lowc4;
-  lowc4.tone = -21;
-  lowc4.duration = 4*EIGHTH;
-  
-  //sky notes
-      note sc;
-  sc.tone = 3;
-  sc.duration = EIGHTH;
-  
-  note  sgsharp;
-  sgsharp.tone = -1;
-  sgsharp.duration = EIGHTH;
-  
-  note sf;
-  sf.tone = -4;
-  sf.duration = EIGHTH;
-    note sasharp;
-  sasharp.tone = 1;
-  sasharp.duration = EIGHTH;
-    note sg;
-  sg.tone = -2;
-  sg.duration = EIGHTH;
-  
-  note se;
-  se.tone = -5;
-  se.duration = EIGHTH;
-  
-  note sdu;
-  sdu.tone = 5;
-  sdu.duration = EIGHTH;
-  
-  note seu;
-  seu.tone = 7;
-  seu.duration = EIGHTH;
-  
-  note sfu;
-  sfu.tone = 8;
-  sfu.duration = EIGHTH;
-    note scd;
-  scd.tone = -9;
-  scd.duration = EIGHTH;
-  
-  note sgu;
-  sgu.tone = 10;
-  sgu.duration = EIGHTH;
-  
-  note scu;
-  scu.tone = 15;
-  scu.duration = EIGHTH;
-  
-  note sbu;
-  sbu.tone = 14;
-  sbu.duration = EIGHTH;
-  
-  note sd;
-  sd.tone = -7;
-  sd.duration = EIGHTH;
-  
-  note stop;
-  stop.tone = STOP;
-  stop.duration = 0;
-  
-   note sgsharpu;
-  sgsharpu.tone = 11;
-  sgsharpu.duration = EIGHTH;
-  
-    note sasharpu;
-  sasharpu.tone = 13;
-  sasharpu.duration = EIGHTH;
-  note sduu;
-  sduu.tone = 17;
-  sduu.duration = EIGHTH;
-   note seuu;
-  seuu.tone = 19;
-  seuu.duration = EIGHTH;
-  note sguu;
-  sguu.tone = 22;
-  sguu.duration = EIGHTH;
-    note nulln;
-  nulln.tone = REST;
-  nulln.duration = EIGHTH * 16;
-    note scuu;
-  scuu.tone = 27;
-  scuu.duration = EIGHTH * 16;
-  
-  //do the allocs
+note drum_loop[] = {
+  kick rest rest kick
+  rest rest kick rest
+  rest rest kick rest
+  snare rest kick rest 
 
-  drums.notes = memblk; //needs 90
-  bassline.notes = drums.notes + 90 ; //needs 44
-  sky.notes = bassline.notes + 44 ; // needs 129
-  drums.realloc_notes();
-  bassline.realloc_notes();
-  sky.realloc_notes();
-  //drums
-  for(int i = 0; i < 4; i++)
-  {
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    switch(i)
-    {
-      case 0: case 2:
-        drums.queue(&rest);
-        break;
-      case 1: case 3:
-        drums.queue(&kick);
-        drums.queue(&kick_rest);
-      break;
-    }
-    drums.queue(&snare);
-    drums.queue(&snare_rest);
-    drums.queue(&rest);
-    switch(i)
-    {
-      case 0:case 1:case 2:
-        drums.queue(&kick);
-        drums.queue(&kick_rest);
-        break;
-      case 3:
-        drums.queue(&snare);
-        drums.queue(&snare_rest);
+  kick rest rest kick
+  rest rest kick rest
+  rest rest kick kick
+  snare rest kick rest
 
-        break;
-    }
-    drums.queue(&rest); 
-  }
- // debug(drums.insert_at);
-  ///HERE'S THE BASSLINE
+  kick rest rest kick
+  rest rest kick rest
+  rest rest kick rest
+  snare rest kick rest
 
-  for(int i = 0; i < 2; i++)
-  {
-    bassline.queue(&gsharp);
-    bassline.queue(&rest);
-    bassline.queue(&rest);
-    bassline.queue(&gsharp);
-    bassline.queue(&rest);
-    bassline.queue(&rest);
-    bassline.queue(&gsharp4);
-    bassline.queue(&gsharp2low);
-    bassline.queue(&gsharp2high);
-    bassline.queue(&gsharp2low);
-    if (i==0)
-    {
-      bassline.queue(&transpose);
-      bassline.queue(&transpose);
-    }
-  }
-    bassline.queue(&transposed);
-    bassline.queue(&transposed);
-    bassline.queue(&c);
-    bassline.queue(&rest);
-    bassline.queue(&rest);
-    bassline.queue(&c);
-    bassline.queue(&rest);
-    bassline.queue(&rest);
-    bassline.queue(&c4);
-    bassline.queue(&g2);
-    bassline.queue(&c2);
-    bassline.queue(&g2);
-    ///
-    bassline.queue(&lowc);
-    bassline.queue(&rest);
-    bassline.queue(&rest);
-    bassline.queue(&lowc);
-    bassline.queue(&rest);
-    bassline.queue(&rest);
-    bassline.queue(&lowc4);
-    bassline.queue(&g2);
-    bassline.queue(&c2);
-    bassline.queue(&g2);
-    
+  kick rest rest kick
+  rest rest kick rest
+  rest rest kick kick
+  snare rest snare rest
+};
+
+#define gsharp      note(-13, EIGHTH),
+#define gsharp4     note(-13, 4*EIGHTH),
+#define gsharp2low  note(-25, 2*EIGHTH),
+#define gsharp2high note(-13, 2*EIGHTH),
+#define transpose   note(TRANSPOSEUP, 0),
+#define transposed  note(TRANSPOSEDOWN, 0),  
+#define g2          note(-14, 2*EIGHTH),
+#define c           note(-9, EIGHTH),
+#define c4          note(-9, 4*EIGHTH),
+#define c2          note(-9, 2*EIGHTH),
+#define lowc        note(-21, EIGHTH),
+#define lowc4       note(-21, 4*EIGHTH),
+
+note part3_bassline[] = {
+  gsharp rest rest gsharp rest rest
+  gsharp4 gsharp2low gsharp2high gsharp2low
+  transpose transpose
+  gsharp rest rest gsharp rest rest
+  gsharp4 gsharp2low gsharp2high gsharp2low
+  transposed transposed
+  c rest rest c rest rest
+  c4 g2 c2 g2
+  lowc rest rest lowc rest rest
+  lowc4 g2 c2 g2
+};
+
+//sky notes
+
+#define sc       note(3,  EIGHTH),
+#define sgsharp  note(-1, EIGHTH),
+#define sf       note(-4, EIGHTH),
+#define sasharp  note(1,  EIGHTH),
+#define sg       note(-2, EIGHTH),
+#define se       note(-5, EIGHTH),
+#define sdu      note(5,  EIGHTH),
+#define seu      note(7,  EIGHTH),
+#define sfu      note(8,  EIGHTH),
+#define scd      note(-9, EIGHTH),
+#define sgu      note(10, EIGHTH),
+#define scu      note(15, EIGHTH),
+#define sbu      note(14, EIGHTH),
+#define sd       note(-7, EIGHTH),
+#define stop     note(STOP, 0),
+#define sgsharpu note(11, EIGHTH),
+#define sasharpu note(13, EIGHTH),
+#define sduu     note(17, EIGHTH),
+#define seuu     note(19, EIGHTH),
+#define sguu     note(22, EIGHTH),
+#define nulln    note(REST, EIGHTH * 16),
+#define scuu     note(27, EIGHTH * 16),
+
+note part3_sky[] = {
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
   
+  sc sasharp sf sgsharp
+  sc sasharp sf sgsharp
+  sc sasharp sf sgsharp
+  sc sasharp sf sgsharp
 
-
-  //HERE'S THE SKY
-  //HERE WE GO
-
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+  sdu sg se sg
   
-  for(int i = 0; i < 4; i++)
-  {
-    sky.queue(&sc);
-    sky.queue(&sgsharp);
-    sky.queue(&sf);
-    sky.queue(&sgsharp);
-  }
+  seu sg se sg
+  sfu sg se sg
+  seu sg se sg
+  sdu sg se sg
 
-  for(int i = 0; i < 4; i++)
-  {
-    sky.queue(&sc);
-    sky.queue(&sasharp);
-    sky.queue(&sf);
-    sky.queue(&sgsharp);
-  }
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sdu sgsharp sf sgsharp
+  seu sgsharp sf sgsharp
+  
+  sc sasharp sf sgsharp
+  sc sasharp sf sgsharp
+  sdu sasharp sf sgsharp
+  seu sasharp sf sgsharp
 
-  
-  for(int i = 0; i < 8; i++)
-  {
-    switch(i)
-    {
-      case 3:
-      case 7:
-      sky.queue(&sdu);
-      break;
-      case 4:
-      case 6:
-      sky.queue(&seu);
-      break;
-      case 5:
-      sky.queue(&sfu);
-      break;
-      default:
-      sky.queue(&sc);
-    }
-    sky.queue(&sg);
-    sky.queue(&se);
-    sky.queue(&sg);
-  }
-  
-  for(int i = 0; i < 8; i++)
-  {
-    switch(i)
-    {
-      case 2:
-      case 6:
-        sky.queue(&sdu);
-        break;
-      case 3:
-      case 7:
-        sky.queue(&seu);
-        break;
-      default:
-      sky.queue(&sc);
-    }
-    if (i<4)
-      sky.queue(&sgsharp);
-    else
-      sky.queue(&sasharp);
-    sky.queue(&sf);
-    sky.queue(&sgsharp);
-  }
   //SLIDE TIME
-
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&sg);
-  sky.queue(&se);
-  sky.queue(&scd);
-  sky.queue(&se);
-  sky.queue(&sg);
-  sky.queue(&sc);
+  seu sc sg se
+  scd se sg sc
   ///
-  sky.queue(&seu);
-  sky.queue(&sgu);
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&sg);
-  sky.queue(&se);
-  sky.queue(&sg);
-  sky.queue(&sc);
-  //
+  seu sgu seu sc
+  sg se sg sc
   
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&sgu);
-  sky.queue(&sc);
-  sky.queue(&scu);
-  sky.queue(&sbu);
-  sky.queue(&sgu);
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&sg);   
-  sky.queue(&se);
-  sky.queue(&sg);
-  sky.queue(&sc);
-  sky.queue(&sg);
-  sky.queue(&sc);
-  sky.queue(&sd);
-  
-  //out of memory here
-
-  sky.queue(&stop);
- m.play();
-  
-  sky.realloc_notes(); //here we go...
-  //more standard-like
-  for(int i = 0; i < 2; i++) {
-  sky.queue(&sc);
-  sky.queue(&sgsharp);
-  sky.queue(&sf);
-  sky.queue(&sgsharp);
-  }
-  sky.queue(&sc);
-  sky.queue(&sdu);
-  sky.queue(&sc);
-  sky.queue(&sgsharp);
-  sky.queue(&sf);
-  sky.queue(&sgsharp);
-  sky.queue(&sc);
-  sky.queue(&sg);
-  ///
+  seu sc sgu sc
+  scu sbu sgu seu
+  sc sg se sg
+  sc sg sc sd
+  // old stop
  
-  sky.queue(&sc);
-  sky.queue(&sasharp);
-  sky.queue(&sf);
-  sky.queue(&sasharp);
-  sky.queue(&sc);
-  sky.queue(&sfu);
-  sky.queue(&sc);
-  sky.queue(&sasharp);
-  sky.queue(&sf);
-  sky.queue(&sasharp);
-  sky.queue(&sc);
-  sky.queue(&sfu);
-  sky.queue(&sgsharpu);
-  sky.queue(&sfu);
-  sky.queue(&sc);
-  sky.queue(&sfu); 
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sdu sc sgsharp
+  sf sgsharp sc sg
+  ///
+  sc sasharp sf sasharp
+  sc sfu sc sasharp
+  sf sasharp sc sfu
+  sgsharpu sfu sc sfu 
   //now measure 35
-  sky.queue(&sc);
-  sky.queue(&sg);
-  sky.queue(&se);
-  sky.queue(&sg);
-  sky.queue(&sc);
-  sky.queue(&seu);
-  sky.queue(&sgu);
-  sky.queue(&scu);
-  sky.queue(&sgu);
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&sg);
-  sky.queue(&se);
-  sky.queue(&scd);
-  sky.queue(&se);
-  sky.queue(&sg);
+  sc sg se sg
+  sc seu sgu scu
+  sgu seu sc sg
+  se scd se sg
   //36
-  sky.queue(&sc);
-  sky.queue(&seu);
-  sky.queue(&sgu);
-  sky.queue(&scu);
-  sky.queue(&sgu);
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&sg);
-  sky.queue(&sc);
-  sky.queue(&sgu);
-  sky.queue(&sc);
-  sky.queue(&scu);
-  sky.queue(&sgu);
-  sky.queue(&sc);
-  sky.queue(&scu);
-  sky.queue(&sc);
+  sc seu sgu scu
+  sgu seu sc sg
+  sc sgu sc scu
+  sgu sc scu sc
   //37
-  for(int i = 0; i < 4; i++)
-  {
-    sky.queue(&scu);
-    sky.queue(&sgsharpu);
-    sky.queue(&sfu);
-    sky.queue(&sgsharpu);
-  }
+  scu sgsharpu sfu sgsharpu
+  scu sgsharpu sfu sgsharpu
+  scu sgsharpu sfu sgsharpu
+  scu sgsharpu sfu sgsharpu
   //38
-
-  for(int i = 0; i < 4; i++)
-  {
-    sky.queue(&sduu);
-    sky.queue(&sasharpu);
-    sky.queue(&sfu);
-    sky.queue(&sasharpu);
-  }
+  sduu sasharpu sfu sasharpu
+  sduu sasharpu sfu sasharpu
+  sduu sasharpu sfu sasharpu
+  sduu sasharpu sfu sasharpu
   
- 
-  sky.queue(&seuu);
-  sky.queue(&scu);
-  sky.queue(&sgu);
-  sky.queue(&seu);
-  sky.queue(&sc);
-  sky.queue(&seu);
-  sky.queue(&sgu);
-  sky.queue(&scu);
-  sky.queue(&seuu);
-  sky.queue(&sguu);
-  sky.queue(&seuu);
-  sky.queue(&scu);
-  sky.queue(&sgu);
-  sky.queue(&scu);
-  sky.queue(&seuu);
-  sky.queue(&scu);
+  seuu scu sgu seu
+  sc seu sgu scu
+  seuu sguu seuu scu
+  sgu scu seuu scu
+  stop
+};
 
-  sky.queue(&stop);
+note part3_null[] = {
+  nulln
+};
+note part3_end[] = {
+  scuu stop
+};
+
+void pt3(channel &drums, channel &bassline, channel& sky)
+{
+  drums.notes = drum_loop;
+  drums.insert_at = NELEMENTS(drum_loop);
+  bassline.notes = part3_bassline;
+  bassline.insert_at = NELEMENTS(part3_bassline);
+  sky.notes = part3_sky;
+  sky.insert_at = NELEMENTS(part3_sky);  
   m.play();
-  
-  sky.notes = memblk; //needs 3
-  bassline.notes = sky.notes + 3 + 1; //needs 2
-  drums.notes = bassline.notes + 2 + 1; //needs 2
-  sky.realloc_notes();
-  bassline.realloc_notes();
-  drums.realloc_notes();
-  //null notes
 
-  drums.queue(&nulln);
-  bassline.queue(&nulln);
-
-  sky.queue(&scuu);
-  sky.queue(&stop);
- m.play();
-}
-inline void pt1(channel& melody, channel& harmony, channel& skyline)
-{
-
-  
-
-note transposed;
-transposed.tone = TRANSPOSEDOWN;
-transposed.duration = 0;
-
-
-  note sc;
-  sc.tone = 27;
-  sc.duration = EIGHTH;
-  
-  note sg;
-  sg.tone = 22;
-  sg.duration = EIGHTH;
-  
-  note se;
-  se.tone = 19;
-  se.duration = EIGHTH;
-  
-  note sgsharp;
-  sgsharp.tone = 23;
-  sgsharp.duration = EIGHTH;
-  note sf;
-  sf.tone = 20;
-  sf.duration = EIGHTH;
-  
-  note sd;
-  sd.tone = 29;
-  sd.duration = EIGHTH;
-  
-  
-    note sasharp;
-    sasharp.tone = 25;
-    sasharp.duration = EIGHTH;
-    
-    ////////MELODY
-note mclong;
-mclong.tone = 3;
-mclong.duration = EIGHTH * 10;
-
-note melong;
-melong.tone = 7;
-melong.duration = EIGHTH * 10;
-
-note mg;
-mg.tone = -2;
-mg.duration = EIGHTH * 2;
-
-note hg;
-hg.tone = 10;
-hg.duration = EIGHTH*2;
-
-note mc;
-mc.tone = 3;
-mc.duration = EIGHTH * 2;
-
-note me;
-me.tone = 7;
-me.duration = EIGHTH * 2;
-
-note mf;
-mf.tone = 8;
-mf.duration = EIGHTH * 4;
-
-
-note md4;
-md4.tone = 5;
-md4.duration = EIGHTH * 4;
-
-note me4;
-me4.tone = 7;
-me4.duration = EIGHTH * 4;
-
-note mc4;
-mc4.tone = 3;
-mc4.duration = EIGHTH * 4;
-
-note mchold;
-mchold.tone = 3;
-mchold.duration = EIGHTH * 24;
-note mchold2;
-mchold2.tone = 3;
-mchold2.duration = EIGHTH*10;
-
-note mghold;
-mghold.tone = 10;
-mghold.duration = EIGHTH * 24;
-note mghold2;
-mghold2.tone = 10;
-mghold2.duration = EIGHTH*10;
-
-note ma4;
-ma4.tone = 12;
-ma4.duration = EIGHTH * 4;
-
-note mg4;
-mg4.tone = 10;
-mg4.duration = EIGHTH * 4;
-
-note mgsharphold;
-mgsharphold.tone = 11;
-mgsharphold.duration = EIGHTH * 18; 
-
-note masharphold;
-masharphold.tone = 13;
-masharphold.duration = EIGHTH * 16;
-
-note mfhold;
-mfhold.tone = 8;
-mfhold.duration = EIGHTH * 16; 
-
-
-//memblk =  (note**) malloc(sizeof(note*) * 265);
-  melody.notes = memblk ;
-  harmony.notes = melody.notes + 50 ; //melody needs 50 notes? round numbers
-  skyline.notes = harmony.notes + 50 ; //harmony needs 50 note? round numbers
-                                      //skyline needs 128 notes exact
-                                      
-     melody.realloc_notes();
-  harmony.realloc_notes();
-  skyline.realloc_notes();
-for(int i = 0; i < 12; i++)
-{
-   harmony.queue(&transposed);
-}
-  for(int k = 0; k < 2; k++)
-  {
-    for(int i = 0; i < 8; i++)
-    {
-      skyline.queue(&sc);
-      skyline.queue(&sg);
-      skyline.queue(&se);
-      skyline.queue(&sg);
-    }
-
-  
-
-    for(int i = 0; i < 4; i++)
-    {
-      skyline.queue(&sc);
-      skyline.queue(&sgsharp);
-      skyline.queue(&sf);
-      skyline.queue(&sgsharp);
-    }
-    for(int i = 0; i < 4; i++)
-    {
-      switch(k){
-        case 0:
-        skyline.queue(&sc);
-        break;
-        case 1:
-        skyline.queue(&sd);
-        break;
-      }
-      skyline.queue(&sasharp);
-      skyline.queue(&sf);
-      skyline.queue(&sasharp);
-    }
-  
-  }
-
-
-for(int i = 0; i < 2; i++)
-{
-  melody.queue(&mclong);
-  harmony.queue(&melong);
-  melody.queue(&mg);
-  harmony.queue(&mc);
-  melody.queue(&mc);
-  harmony.queue(&me);
-  melody.queue(&me);
-  harmony.queue(&hg);
-  melody.queue(&mf);
-  harmony.queue(&ma4);
-  melody.queue(&me);
-  harmony.queue(&hg);
-  melody.queue(&md4);
-  harmony.queue(&mf);
-  switch(i){
-    case 0:
-      melody.queue(&me4);
-      harmony.queue(&mg4);
-      melody.queue(&mchold);
-      harmony.queue(&mgsharphold);
-      harmony.queue(&mfhold);
-      melody.queue(&mchold2);
-      skyline.queue(&sc);
-      break;
-    case 1:
-      melody.queue(&mc4);
-      harmony.queue(&me4);
-      melody.queue(&mghold);
-      harmony.queue(&mgsharphold);
-      melody.queue(&mghold2);
-      harmony.queue(&masharphold);
-      break; 
-  }
-}
-note stop;
-stop.tone = STOP;
-stop.duration = 0;
-  melody.queue(&stop);
-
+  drums.notes = part3_null;
+  drums.insert_at = NELEMENTS(part3_null);
+  bassline.notes = part3_null;
+  bassline.insert_at = NELEMENTS(part3_null);
+  sky.notes = part3_end;
+  sky.insert_at = NELEMENTS(part3_end);
   m.play();
-  
 }
-inline void pt2(channel& melody, channel& bassline, channel& drums)
+
+#define sc note(27, EIGHTH),
+#define sg note(22, EIGHTH),
+#define se note(19, EIGHTH),
+#define sgsharp note(23, EIGHTH),
+#define sf note(20, EIGHTH),
+#define sd note(29, EIGHTH),
+#define sasharp note(25, EIGHTH),
+#define mclong note(3, EIGHTH * 10),
+#define melong note(7, EIGHTH * 10),
+#define mg note(-2, EIGHTH * 2),
+#define hg note(10, EIGHTH*2),
+#define mc note(3, EIGHTH * 2),
+#define me note(7, EIGHTH * 2),
+#define mf note(8, EIGHTH * 4),
+#define md4 note(5, EIGHTH * 4),
+#define me4 note(7, EIGHTH * 4),
+#define mc4 note(3, EIGHTH * 4),
+#define mchold note(3, EIGHTH * 24),
+#define mchold2 note(3, EIGHTH*10),
+#define mghold note(10, EIGHTH * 24),
+#define mghold2 note(10, EIGHTH*10),
+#define ma4 note(12, EIGHTH * 4),
+#define mg4 note(10, EIGHTH * 4),
+#define mgsharphold note(11, EIGHTH * 18), 
+#define masharphold note(13, EIGHTH * 16),
+#define mfhold note(8, EIGHTH * 16), 
+
+note part1_skyline[] = {
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+
+  sc sasharp sf sasharp 
+  sc sasharp sf sasharp 
+  sc sasharp sf sasharp 
+  sc sasharp sf sasharp 
+
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+  sc sg se sg
+
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+  sc sgsharp sf sgsharp
+
+  sd sasharp sf sasharp
+  sd sasharp sf sasharp
+  sd sasharp sf sasharp
+  sd sasharp sf sasharp
+  sc
+};
+
+
+note part1_melody[] = {
+  mclong
+  mg
+  mc
+  me
+  mf
+  me
+  md4
+  me4
+  mchold
+  mchold2
+
+  mclong
+  mg
+  mc
+  me
+  mf
+  me
+  md4
+  mc4
+  mghold
+  mghold2
+  
+  stop
+};
+
+
+note part1_harmony[] = {
+  transposed transposed transposed transposed transposed transposed
+  transposed transposed transposed transposed transposed transposed
+
+  melong
+  mc
+  me
+  hg
+  ma4
+  hg
+  mf
+
+  mg4
+  mgsharphold
+  mfhold
+
+  melong
+  mc
+  me
+  hg
+  ma4
+  hg
+  mf
+
+  me4
+  mgsharphold
+  masharphold
+};
+
+void pt1(channel& melody, channel& harmony, channel& skyline)
 {
-   ///OK HERES THE DRUM LOOP
-  note kick;
-  kick.tone = KICK;
-  kick.duration = KICK_LEN;
-  
-  note kick_rest;
-  kick_rest.tone = REST;
-  kick_rest.duration = EIGHTH-KICK_LEN;
-  
-  note snare;
-  snare.tone = SNARE;
-  snare.duration = SNARE_LEN;
-  
-  note snare_rest;
-  snare_rest.tone = REST;
-  snare_rest.duration = EIGHTH-SNARE_LEN;
-  
-  note rest;
-  rest.tone = REST;
-  rest.duration = EIGHTH;
-  
-   drums.notes = memblk; //needs 90
-   bassline.notes = drums.notes + 90; //needs 58
-   melody.notes = bassline.notes + 58;
+  melody.notes = part1_melody;
+  melody.insert_at = NELEMENTS(part1_melody);
+  harmony.notes = part1_harmony;
+  harmony.insert_at = NELEMENTS(part1_harmony);
+  skyline.notes = part1_skyline;
+  skyline.insert_at = NELEMENTS(part1_skyline);
+  m.play();
+}
 
-   drums.realloc_notes();
-   bassline.realloc_notes();
-   melody.realloc_notes();
-    for(int i = 0; i < 4; i++)
-  {
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&rest);
-    drums.queue(&kick);
-    drums.queue(&kick_rest);
-    switch(i)
-    {
-      case 0: case 2:
-        drums.queue(&rest);
-        break;
-      case 1: case 3:
-        drums.queue(&kick);
-        drums.queue(&kick_rest);
-      break;
-    }
-    drums.queue(&snare);
-    drums.queue(&snare_rest);
-    drums.queue(&rest);
-    switch(i)
-    {
-      case 0:case 1:case 2:
-        drums.queue(&kick);
-        drums.queue(&kick_rest);
-        break;
-      case 3:
-        drums.queue(&snare);
-        drums.queue(&snare_rest);
+#define bc note(-21, EIGHTH),
+#define bc2 note(-21, EIGHTH * 2),
+#define bchigh note(-9, EIGHTH * 2),
+#define bgsharp note(-13, EIGHTH * 2),
+#define basharp note(-11, EIGHTH * 2),
 
-        break;
-    }
-    drums.queue(&rest); 
-  }
-  //bassline
-  ////
+note part2_bassline[] = {
+  bc2 rest
+  bc2 rest 
+  bc2 rest
+  rest bc2
+  
+  bchigh bc2
+
+  bc2 rest
+  bc2 rest
+  bc2 rest
+  rest bc2
+
+  bchigh bc2
+  
+  bgsharp rest
+  bgsharp rest
+  bgsharp rest
+  rest bgsharp
+
+  bchigh bgsharp
+  
+  basharp rest
+  basharp rest
+  basharp rest
+  rest basharp
+  
+  bchigh bgsharp  
+};
+
+#define mch note(-9, EIGHTH*10),
+#define mg note(-14, EIGHTH*2),
+#define mg4 note(-14, EIGHTH*4),
+#define mg1 note(-14, EIGHTH*1),
+#define mgold note(-2, EIGHTH * 12),
+#define mc note(-9, EIGHTH * 2),
+#define mcsharp1 note(-8, EIGHTH),
+#define mc1 note(-9, EIGHTH * 1),
+#define mcl note(-21, EIGHTH * 2),
+#define mc4 note(-9, EIGHTH * 4),
+#define me note(-5, EIGHTH * 2),
+#define me1 note(-5, EIGHTH * 1),
+#define mel8 note(-17, EIGHTH * 8),
+#define mf4 note(-4, EIGHTH * 4),
+#define mfl1 note(-16, EIGHTH),
+#define mf note(-4, EIGHTH * 2),
+#define mf1 note(-4, EIGHTH),
+#define md1 note(-7, EIGHTH),
+#define mdl note(-19, EIGHTH * 2),
+#define md4 note(-7, EIGHTH * 4),
+#define me4 note(-5, EIGHTH * 4),
+#define mchh note(-9, EIGHTH * 14),
+#define mcsecondhh note(-9, EIGHTH * 8),
+#define soloON note(SUPERSOLO, 1),
+#define soloOFF note(SUPERSOLO, 0),
+#define mgsharp note(-13, 2 * EIGHTH),
+#define mgsharp10 note(-13, 10 * EIGHTH),
+#define frest note(REST, EIGHTH / 2),
+#define moreSOLO note(SUPERSOLO, 1),
+#define stop note(STOP, 0),
+
+note part2_melody[] = {
+  mch mg mc me mf4 me md4
+  me soloON me soloOFF mchh
+  rest rest rest rest
+  //m12
+  mc4 mgsharp mc4 md4 mc  
+  mch mg mc me
+  //m13
+  mf4 me md4 mc4 mc
+  //m14
+  mgold mf me
+  //m15
+  mf1 me1 mc1 mg1 mg4 mg4
   ///
-  note bc;
-  bc.tone = -21;
-  bc.duration = EIGHTH;
-  
-  note bc2;
-  bc2.tone = -21;
-  bc2.duration = EIGHTH * 2;
-  
-  note bchigh;
-  bchigh.tone = -9;
-  bchigh.duration = EIGHTH * 2;
-  
-  note bgsharp;
-  bgsharp.tone = -13;
-  bgsharp.duration = EIGHTH * 2;
-  
-  note basharp;
-  basharp.tone = -11;
-  basharp.duration = EIGHTH * 2;
-    
-for(int i = 0; i < 4; i++)
+  mf1 me1 moreSOLO mc1 mg1 soloOFF
+  //again
+  mch mg mc me mf4 me md4
+  me
+  moreSOLO me1 me1 md1 mcsharp1 soloOFF
+  mcsecondhh
+  mc mg mc mg mgsharp10 mfl1 mfl1 mgsharp mc
+  mg4 mg mc4
+  mg mc me mf4 me md4 mc4 rest mc1
+  mgold mf me
+  mf1 me1 mc1 mfl1 mel8 mdl mcl
+  stop
+};
+
+void pt2(channel& melody, channel& bassline, channel& drums)
 {
-  for(int k = 0; k < 3; k++)
-  {
-    switch(i)
-    {
-      case 0:
-      case 1:
-      bassline.queue(&bc2);
-      break;
-      case 2:
-      bassline.queue(&bgsharp);
-      break;
-      case 3:
-      bassline.queue(&basharp);
-      break;
-      
-    }
-    bassline.queue(&rest); 
-
-  }
-    bassline.queue(&rest);
-    switch(i)
-    {
-      case 0:
-      case 1:
-      bassline.queue(&bc2);
-      break;
-      case 2:
-      bassline.queue(&bgsharp);
-
-      break;
-      case 3:
-      bassline.queue(&basharp);
-
-      break;
-      
-    }
-
-bassline.queue(&bchigh);
-    switch(i)
-    {
-      case 0:
-      case 1:
-      bassline.queue(&bc2);
-      break;
-      case 2:
-      bassline.queue(&bgsharp);
-      break;
-      case 3:
-      bassline.queue(&basharp);
-      break;
-      
-    }
-}
-    
-/*   bassline.queue(&bc2);
-  bassline.queue(&bchigh);
- bassline.queue(&bc2);*/
-    
-  
-
-//melody
-note mch;
-mch.tone=-9;
-mch.duration = EIGHTH*10;
-note mg;
-mg.tone = -14;
-mg.duration = EIGHTH*2;
-
-note mg4;
-mg4.tone = -14;
-mg4.duration = EIGHTH*4;
-
-note mg1;
-mg1.tone = -14;
-mg1.duration = EIGHTH*1;
-
-note mgold;
-mgold.tone = -2;
-mgold.duration = EIGHTH * 12;
-
-note mc;
-mc.tone = -9;
-mc.duration = EIGHTH * 2;
-
-note mcsharp1;
-mcsharp1.tone = -8;
-mcsharp1.duration = EIGHTH;
-
-note mc1;
-mc1.tone = -9;
-mc1.duration = EIGHTH * 1;
-
-note mcl;
-mcl.tone = -21;
-mcl.duration = EIGHTH * 2;
-
-note mc4;
-mc4.tone = -9;
-mc4.duration = EIGHTH * 4;
-
-note me;
-me.tone = -5;
-me.duration = EIGHTH * 2;
-
-note me1;
-me1.tone = -5;
-me1.duration = EIGHTH * 1;
-
-note mel8;
-mel8.tone = -17;
-mel8.duration = EIGHTH * 8;
-
-note mf4;
-mf4.tone = -4;
-mf4.duration = EIGHTH * 4;
-
-note mfl1;
-mfl1.tone = -16;
-mfl1.duration = EIGHTH;
-
-note mf;
-mf.tone = -4;
-mf.duration = EIGHTH * 2;
-
-note mf1;
-mf1.tone = -4;
-mf1.duration = EIGHTH;
-
-
-note md1;
-md1.tone = -7;
-md1.duration = EIGHTH;
-
-note mdl;
-mdl.tone = -19;
-mdl.duration = EIGHTH * 2;
-note md4;
-md4.tone = -7;
-md4.duration = EIGHTH * 4;
-
-note me4;
-me4.tone = -5;
-me4.duration = EIGHTH * 4;
-
-note mchh;
-mchh.tone = -9;
-mchh.duration = EIGHTH * 14;
-
-note mcsecondhh;
-mcsecondhh.tone = -9;
-mcsecondhh.duration = EIGHTH * 8;
-
-note soloON;
-soloON.tone = SUPERSOLO;
-soloON.duration = 1;
-
-note soloOFF;
-soloOFF.tone = SUPERSOLO;
-soloOFF.duration = 0;
-
-note mgsharp;
-mgsharp.tone = -13;
-mgsharp.duration = 2 * EIGHTH;
-
-note mgsharp10;
-mgsharp10.tone = -13;
-mgsharp10.duration = 10 * EIGHTH;
-
-note frest;
-frest.tone = REST;
-frest.duration = EIGHTH / 2;
-
-note moreSOLO;
-moreSOLO.tone = SUPERSOLO;
-moreSOLO.duration = 1;
-
-note stop;
-stop.tone = STOP;
-stop.duration = 0;
-
-
-melody.queue(&mch);
-melody.queue(&mg);
-melody.queue(&mc);
-melody.queue(&me);
-melody.queue(&mf4);
-melody.queue(&me);
-melody.queue(&md4);
-
-melody.queue(&me);
-melody.queue(&soloON);
-melody.queue(&me);
-melody.queue(&soloOFF);
-melody.queue(&mchh);
-melody.queue(&rest);
-melody.queue(&rest);
-melody.queue(&rest);
-melody.queue(&rest);
-//m12
-
-melody.queue(&mc4);
-melody.queue(&mgsharp);
-melody.queue(&mc4);
-melody.queue(&md4);
-melody.queue(&mc);
-
-melody.queue(&mch);
-melody.queue(&mg);
-melody.queue(&mc);
-melody.queue(&me);
-//m13
-melody.queue(&mf4);
-melody.queue(&me);
-melody.queue(&md4);
-melody.queue(&mc4);
-melody.queue(&mc);
-//m14
-melody.queue(&mgold);
-melody.queue(&mf);
-melody.queue(&me);
-//m15
-melody.queue(&mf1);
-melody.queue(&me1);
-melody.queue(&mc1);
-melody.queue(&mg1);
-melody.queue(&mg4);
-melody.queue(&mg4);
-///
-melody.queue(&mf1);
-melody.queue(&me1);
-melody.queue(&moreSOLO);
-melody.queue(&mc1);
-melody.queue(&mg1);
-melody.queue(&soloOFF);
-
-//again
-melody.queue(&mch);
-melody.queue(&mg);
-melody.queue(&mc);
-melody.queue(&me);
-melody.queue(&mf4);
-melody.queue(&me);
-melody.queue(&md4);
-
-melody.queue(&me);
-
-melody.queue(&moreSOLO);
-melody.queue(&me1);
-melody.queue(&me1);
-melody.queue(&md1);
-melody.queue(&mcsharp1);
-melody.queue(&soloOFF);
-
-melody.queue(&mcsecondhh);
-
-
-melody.queue(&mc);
-melody.queue(&mg);
-melody.queue(&mc);
-melody.queue(&mg);
-melody.queue(&mgsharp10);
-melody.queue(&mfl1);
-melody.queue(&mfl1);
-melody.queue(&mgsharp);
-melody.queue(&mc);
-
-melody.queue(&mg4);
-melody.queue(&mg);
-melody.queue(&mc4);
-
-melody.queue(&mg);
-melody.queue(&mc);
-melody.queue(&me);
-melody.queue(&mf4);
-melody.queue(&me);
-melody.queue(&md4);
-melody.queue(&mc4);
-melody.queue(&rest);
-melody.queue(&mc1);
-
-melody.queue(&mgold);
-melody.queue(&mf);
-melody.queue(&me);
-
-melody.queue(&mf1);
-melody.queue(&me1);
-melody.queue(&mc1);
-melody.queue(&mfl1);
-melody.queue(&mel8);
-melody.queue(&mdl);
-melody.queue(&mcl);
-
-
-melody.queue(&stop);
+  drums.notes = drum_loop;
+  drums.insert_at = NELEMENTS(drum_loop);
+  bassline.notes = part2_bassline;
+  bassline.insert_at = NELEMENTS(part2_bassline);
+  melody.notes = part2_melody;
+  melody.insert_at = NELEMENTS(part2_melody);
   m.play();
+}
+
+void setup(){
+  m.add_channel(&pin10);
+  m.add_channel(&pin11);
+  m.add_channel(&pin12); //LOUD PIN
+}
+
+void loop() {
+  pt1(pin10,pin11,pin12);
+  pt2(pin12,pin11,pin10);
+  pt3(pin12,pin11,pin10);
 }


### PR DESCRIPTION
The memory for the notes is now allocated as a static array. This helps
avoid memory exhaustion. Also macros are used now to define the notes,
resulting in somewhat tighter song definitions (though less expressive,
since for loops cannot be used).
